### PR TITLE
Fix directory traversal vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@awesomeorganization/static-handler",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@awesomeorganization/static-handler",
   "description": "[ESM] The static handler for Node.js according to rfc7230, rfc7231, rfc7232, rfc7233, rfc7234 and whatwg",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "exports": "./main.js",
   "type": "module",
   "repository": "github:awesomeorganization/static-handler",


### PR DESCRIPTION
This patch fixes access to files outside of http root directory (passed
as directoryPath option), e.g. /etc/passwd.

The issues are reproducible by sending 'GET //etc/passwd' and
'GET /../../../../../etc/passwd' and similar via telnet, or using curl:

curl -D - http://192.168.1.1:8080//etc/passwd

Now all requests are checked for being within the root directory
including it itself.
    
Additional path.normalize() is required to handle some corner cases
on Windows platform.

Signed-off-by: Vitaly Kuzmichev <vkuzmichev@dev.rtsoft.ru>